### PR TITLE
escape alg product

### DIFF
--- a/Bellmansgap.py
+++ b/Bellmansgap.py
@@ -316,8 +316,8 @@ def calculategapc(program, command, name, exlist):
     res = []
 
     # this is the executed commandstring
-    commandstring = 'gapc -p ' + command \
-                    + ' -o ' + dirstr + '/' + name + '_gapc.cc ' \
+    commandstring = 'gapc -p "' + command \
+                    + '" -o ' + dirstr + '/' + name + '_gapc.cc ' \
                     + program + '.gap' + ' 2>&1'
     pro1_returncode = 0
 


### PR DESCRIPTION
we should better escape the algebra product specification, as we are using chars like `*` that might have strange side effects in bash